### PR TITLE
SupportingLinks indexing

### DIFF
--- a/pyxlsb2/ptgs.py
+++ b/pyxlsb2/ptgs.py
@@ -634,7 +634,7 @@ class Ref3dPtg(ClassifiedPtg):
         supporting_link, first_sheet_idx, last_sheet_idx = workbook.resolve_extern_sheet_id(self.extern_sheet_idx)
 
         address = None
-        if supporting_link.brt == rt.SUP_SAME or supporting_link.brt == rt.SUP_SELF:
+        if supporting_link.brt in rt._SUP_LINK_TYPES:
             if first_sheet_idx == last_sheet_idx and first_sheet_idx >= 0:
                 address = workbook.sheets[first_sheet_idx].name + '!' + cell_add
             elif first_sheet_idx == last_sheet_idx and first_sheet_idx == -2:
@@ -691,7 +691,7 @@ class Area3dPtg(ClassifiedPtg):
         supporting_link, first_sheet_idx, last_sheet_idx = workbook.resolve_extern_sheet_id(self.extern_sheet_idx)
 
         address = None
-        if supporting_link.brt == rt.SUP_SAME or supporting_link.brt == rt.SUP_SELF:
+        if supporting_link.brt in rt._SUP_LINK_TYPES:
             if first_sheet_idx == last_sheet_idx and first_sheet_idx >= 0:
                 address = workbook.sheets[first_sheet_idx].name + '!' + first + ':' + last
 

--- a/pyxlsb2/ptgs.py
+++ b/pyxlsb2/ptgs.py
@@ -698,13 +698,16 @@ class Area3dPtg(ClassifiedPtg):
                                   ,self.last_row_rel)
         supporting_link, first_sheet_idx, last_sheet_idx = workbook.resolve_extern_sheet_id(self.extern_sheet_idx)
 
+        cell_add_first = self.cell_address(self.first_col, self.first_row, self.first_col_rel, self.first_row_rel)
+        cell_add_last = self.cell_address(self.last_col, self.last_row, self.last_col_rel, self.last_row_rel)
+
         address = None
         if supporting_link.brt in rt._SUP_LINK_TYPES:
             if first_sheet_idx == last_sheet_idx and first_sheet_idx >= 0:
                 address = workbook.sheets[first_sheet_idx].name + '!' + first + ':' + last
 
         if address is None:
-            print("AreaPtg External Address Not Supported {0} {1} {2}".format(cell_add, first_sheet_idx, last_sheet_idx))
+            print("AreaPtg External Address Not Supported {0}:{1} {2} {3}".format(cell_add_first, cell_add_last, first_sheet_idx, last_sheet_idx))
             #raise NotImplementedError('External address not supported')
 
         return address

--- a/pyxlsb2/recordtypes.py
+++ b/pyxlsb2/recordtypes.py
@@ -779,3 +779,5 @@ REVISION_PTR = 3073
 
 _by_name = {k: v for k, v in locals().items() if not k.startswith('_')}
 _by_num = {v: k for k, v in _by_name.items()}
+# https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-xlsb/8cc503eb-12ab-4a47-bbc7-2dbcef47150b
+_SUP_LINK_TYPES = {SUP_SELF, SUP_SAME, SUP_ADDIN, SUP_BOOK_SRC}

--- a/pyxlsb2/workbook.py
+++ b/pyxlsb2/workbook.py
@@ -61,7 +61,7 @@ class Workbook(object):
                     self.externals = {'SupportingLinks':[], 'ExternalSheets': []}
                 elif rectype == rt.EXTERN_SHEET:
                     self.externals['ExternalSheets'] = rec
-                elif rectype == rt.SUP_SELF or rectype == rt.SUP_SAME:
+                elif rectype in {rt.SUP_SELF, rt.SUP_SAME, rt.SUP_ADDIN, rt.SUP_BOOK_SRC}:
                     self.externals['SupportingLinks'].append(rec)
                 elif rectype == rt.NAME:
                     self.list_names.append(rec.name)

--- a/pyxlsb2/workbook.py
+++ b/pyxlsb2/workbook.py
@@ -61,7 +61,7 @@ class Workbook(object):
                     self.externals = {'SupportingLinks':[], 'ExternalSheets': []}
                 elif rectype == rt.EXTERN_SHEET:
                     self.externals['ExternalSheets'] = rec
-                elif rectype in {rt.SUP_SELF, rt.SUP_SAME, rt.SUP_ADDIN, rt.SUP_BOOK_SRC}:
+                elif rectype in rt._SUP_LINK_TYPES:
                     self.externals['SupportingLinks'].append(rec)
                 elif rectype == rt.NAME:
                     self.list_names.append(rec.name)

--- a/pyxlsb2/worksheet.py
+++ b/pyxlsb2/worksheet.py
@@ -83,7 +83,8 @@ class Worksheet(object):
                 row_num = rec.r
                 row = Row(self, row_num)
             elif rectype == rt.CELL_ISST:
-                row._add_cell(rec.c, self.workbook.get_shared_string(rec.v), rec.f, rec.style)
+                row._add_cell(rec.c, self.workbook.get_shared_string(rec.v) if rec.v else None,
+                              rec.f, rec.style)
             elif rectype >= rt.CELL_BLANK and rectype <= rt.FMLA_ERROR:
                 row._add_cell(rec.c, rec.v, rec.f, rec.style)
             elif rectype == rt.END_SHEET_DATA:


### PR DESCRIPTION
Currently only records of type SUP_SELF and SUP_SAME are added to the list of supporting links in workbook.externals['SupportingLinks']. This can sometimes cause bad indexing in the workbook.resolve_extern_sheet_id method when there is a supporting link record of type SUP_ADDIN  or SUP_BOOK_SRC in the workbook. The externalLink of  EXTERNAL_SHEET records (Xti structures) indexes on the list of all supporting link records in a section: See https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-xlsb/741826f2-e174-43f8-b099-f97cdf360dee. If a supporting link record is in the workbook but not in the supporting links list the externalLink indexes won't line up and can be out of range causing an IndexError.

Adding SUP_BOOK_SRC and SUP_ADDIN to the list of supporting links ensures that the list includes all supporting link records: https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-xlsb/8cc503eb-12ab-4a47-bbc7-2dbcef47150b. 

This fixes the IndexError in https://github.com/DissectMalware/pyxlsb2/issues/7 but NotImplimentedError("External Address not supported") is raised since the firstSheet and lastSheet values are -1. On a file with a SUP_BOOK_SRC record but no negative firstSheet and lastSheet values these changes allowed the workbook to be opened successfully.